### PR TITLE
Fix node >= v22.18.0 internalModuleStat requires 1 arg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "esm-wallaby",
-  "version": "3.2.31",
+  "version": "3.2.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "esm-wallaby",
-      "version": "3.2.31",
+      "version": "3.2.35",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.14.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esm-wallaby",
-  "version": "3.2.34",
+  "version": "3.2.35",
   "description": "Tomorrow's ECMAScript modules today!",
   "keywords": "commonjs, ecmascript, export, import, modules, node, require",
   "repository": "standard-things/esm",

--- a/src/fs/stat-fast.js
+++ b/src/fs/stat-fast.js
@@ -11,7 +11,7 @@ function init() {
   const { isFile } = Stats.prototype
 
   let useFastPath
-  let twoArgsInternalModuleStat = gte(safeProcess.versions.node, "22.10.0") && lt(safeProcess.versions.node, "24.0.0")
+  let twoArgsInternalModuleStat = gte(safeProcess.versions.node, "22.10.0") && lt(safeProcess.versions.node, "22.18.0")
 
   function statFast(thePath) {
     if (typeof thePath !== "string") {


### PR DESCRIPTION
node v22.18.0 internalModuleStat requires 1 arg now

https://github.com/nodejs/node/pull/58054/files#diff-70e3325bd2115867617ae2a16321c5de53c070ff2841976fe5b849675a5111e6L1059